### PR TITLE
rewrite for ScriptHash

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ http://localhost:3456/?server=proxy.genx.zelcore.io&call=history&param=CL19a3der
 parameters - > call, server, param, port, contype, coin (as defined in bitgo-utxo-lib, required for nice calls)
 
 possible calls
-balance = blockchainAddress_getBalance, param = address
-history = blockchainAddress_getHistory, param = address 
+balance = blockchainScripthash_getBalance, param = address
+history = blockchainScripthash_getHistory, param = address
 transaction = blockchainTransaction_get, param = txid
-utxo = blockchainAddress_listunspent, param = address
+utxo = blockchainScripthash_listunspent, param = address
 broadcast = blockchainTransaction_broadcast, param = rawtx
 height = blockchainHeaders_subscribe, no parameter
 header = blockchainBlock_getHeader, param = height

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ function onRequest(req, res) {
           res.end()
         }
       } catch (e) {
-        res.write(JSON.stringify(e))
+        res.write("Error: " + e.message)
         res.end()
       }
       await ecl.close(); // disconnect(promise)
@@ -199,7 +199,7 @@ function onRequest(req, res) {
         res.end()
       } catch (e) {
         console.log(e)
-        res.write(JSON.stringify(e))
+        res.write("Error: " + e.message)
         res.end()
       }
       await ecl.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electrum-http",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electrum-http",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrum-http",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Service that takes http requests asks specific electrum server in socket and returns electrums response",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrum-http",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Service that takes http requests asks specific electrum server in socket and returns electrums response",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In order to support latest electrumx that no longer has address calls, we are rewriting a given address to a scripthash. 
This is a server update of ours only and does not conflict with any zelcore version
Next development version shall focus on supporting a given scripthash by zelcore directly instead